### PR TITLE
Update to async-std 1.9, change UDP stream implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,13 @@ ed25519-dalek = "1.0.0-pre.4"
 blake2 = "0.9.0"
 lru = "0.5.3"
 smallvec = "1.4.1"
-async-std = "1.6.2"
+async-std = "1.9"
 either = "1.5.3"
 
 [features]
 cli = ["structopt"]
 
 [dev-dependencies]
-async-std = { version = "1.6.2", features = [ "attributes" ] }
+async-std = { version = "1.9", features = [ "attributes" ] }
+env_logger = "0.8.3"
 

--- a/src/rpc/udp.rs
+++ b/src/rpc/udp.rs
@@ -13,6 +13,9 @@ use bytes::BytesMut;
 use futures::{pin_mut, ready, Future, Sink};
 use futures_codec::{Decoder, Encoder};
 
+pub type RecvFuture =
+    Pin<Box<dyn Future<Output = io::Result<(Vec<u8>, usize, SocketAddr)>> + Send + Sync>>;
+
 /// A unified `Stream` and `Sink` interface to an underlying `UdpSocket`, using
 /// the `Encoder` and `Decoder` traits to encode and decode frames.
 ///
@@ -38,9 +41,7 @@ pub struct UdpFramed<C> {
     wr: BytesMut,
     out_addr: SocketAddr,
     flushed: bool,
-    recv_fut: Option<
-        Pin<Box<dyn Future<Output = io::Result<(Vec<u8>, usize, SocketAddr)>> + Send + Sync>>,
-    >,
+    recv_fut: Option<RecvFuture>,
 }
 
 impl<C: Decoder + Unpin> fmt::Debug for UdpFramed<C> {


### PR DESCRIPTION
This updates the async-std dependency from `1.6.2` to `1.9`. The update initially broke reading from the UDP socket. A fix is included in this PR.

- The poll_next method of UdpFramed now stores the `socket.recv_from`
  future, the old behavior of recreating the future on each poll is no  longer supported by async_std.
  See [this issue](https://github.com/async-rs/async-std/issues/955)
  for details.
- I couldn't get storing the future to work with BytesMut because all references   or raw pointers seem to be not Send which is needed for it to work  across the await. Thus I changed to a vec, which should be fine too,  but not sure.