### PR TITLE
Use port from peer if 0

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -297,6 +297,7 @@ impl HyperDht {
                 // callback
                 let port = peer
                     .port
+                    .filter(|port| *port != 0)
                     .and_then(|port| u16::try_from(port).ok())
                     .unwrap_or_else(|| query.peer.addr.port());
 


### PR DESCRIPTION
The JS version of dht-rpc may send the port as 0 - and it should instead
use the port where we received the message from the peer, instead of
using 0 as a port.

```
hyperswarm_dht: peer=Ok(PeersInput { port: Some(0), local_address: None, unannounce: None })
```