### PR TITLE
DHT-RPC request ids are only u16 numbers

### DIFF
--- a/src/rpc/io.rs
+++ b/src/rpc/io.rs
@@ -220,7 +220,7 @@ where
 
     fn request(&mut self, mut ev: MessageEvent<TUserData>) {
         let (msg, peer) = ev.inner_mut();
-        msg.rid = self.next_req_id().0;
+        msg.rid = self.next_req_id().0 as u64;
 
         if msg.is_holepunch() && peer.referrer.is_some() {
             match &ev {

--- a/src/rpc/message.rs
+++ b/src/rpc/message.rs
@@ -154,7 +154,7 @@ impl Message {
     }
 
     pub(crate) fn get_request_id(&self) -> RequestId {
-        RequestId(self.rid)
+        RequestId(self.rid as u16)
     }
 
     pub(crate) fn key(&self, peer: &Peer) -> Option<kbucket::Key<PeerId>> {

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -1040,7 +1040,7 @@ impl Response {
 /// Unique identifier for a request. Must be passed back in order to answer a
 /// request from the remote.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
-pub struct RequestId(pub(crate) u64);
+pub struct RequestId(pub(crate) u16);
 
 #[derive(Debug)]
 pub enum RpcDhtEvent {

--- a/src/rpc/query/mod.rs
+++ b/src/rpc/query/mod.rs
@@ -552,7 +552,7 @@ impl From<CommandQuery> for CommandQueryResponse {
         let msg = Message {
             version: Some(VERSION),
             r#type: Type::Response.id(),
-            rid: q.rid.0,
+            rid: q.rid.0 as u64,
             to: Some(q.peer.encode()),
             id: None,
             target: None,


### PR DESCRIPTION
The protobuf encoding uses u64 space, but the
[implementation is only](https://github.com/mafintosh/dht-rpc/blob/19a0df46cd63ec0ddfff16b7ffab77d384e0c4db/lib/io.js#L49)
u16.

This was causing interop issues and generating `InResponseBadRequestId`
as the number we receive was not being found on the request/response
map.